### PR TITLE
optional .babelrc

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ startd is a collection of [toolboxes](https://youtu.be/G39lKaONAlA?t=1398) ðŸ› ð
 
 ## Getting started
 
-_note: startd uses webpack+babel to compile your app. If your project doesn't already have a .babelrc file, you'll need to create one. check out the [docs](https://babeljs.io/docs/usage/babelrc/), or our example_
+_note: startd uses webpack+babel to compile your app. By default it will use the [react babel preset](https://babeljs.io/docs/plugins/preset-react/), but if you want to add other transpile options you can create a .babelrc file in your app directory_
 
 ### yarn
 

--- a/packages/startd-server/lib/index.js
+++ b/packages/startd-server/lib/index.js
@@ -59,11 +59,12 @@ if (!_fs2.default.existsSync(appPath)) {
 }
 
 if (!_findUp2.default.sync(".babelrc", { cwd: _path2.default.dirname(appPath) })) {
-  _logger2.default.error("Looks like you don't have a .babelrc file set up for your app. \uD83D\uDC7B");
-  process.exit(1);
+  _logger2.default.info("Looks like you don't have a .babelrc file set up for your app \uD83D\uDC7B");
+  _logger2.default.info("  * by default startd transpiles your app using the react babel preset");
+  _logger2.default.info("  * add a .babelrc file for other transpile options");
 }
 
-_logger2.default.info(_chalk2.default.gray("Starting webpack compilation... 🕸"));
+_logger2.default.info("Starting webpack compilation... 🕸");
 
 var appConfig = _webpackConfig2.default.map(function (singleConfig) {
   return _extends({}, singleConfig, {
@@ -91,8 +92,8 @@ var appConfig = _webpackConfig2.default.map(function (singleConfig) {
     // if we're in development mode, run a dev server in parallel, to enable
     // watch mode and hot module replacement for the client code
     if (process.env.NODE_ENV !== "production") {
-      _logger2.default.info(_chalk2.default.gray('startd running in dev mode 🛠  make sure to add "--prod" flag when running in production'));
-      _logger2.default.info(_chalk2.default.gray("🛠  compiling webpack for dev server... 🕸"));
+      _logger2.default.info('startd running in dev mode 🛠  make sure to add "--prod" flag when running in production');
+      _logger2.default.info("🛠  compiling webpack for dev server... 🕸");
       var Koa = require("koa");
       var webpackDevMiddleware = require("koa-webpack");
 

--- a/packages/startd-server/lib/logger.js
+++ b/packages/startd-server/lib/logger.js
@@ -46,7 +46,7 @@ var debugLogger = _winston2.default.createLogger({
 
 var _default = {
   info: function info(message) {
-    logger.log("info", message);
+    logger.log("info", _chalk2.default.gray(message));
   },
   error: function error(message) {
     logger.log("error", message);

--- a/packages/startd-server/lib/webpack.config.js
+++ b/packages/startd-server/lib/webpack.config.js
@@ -25,7 +25,10 @@ var baseConfig = {
     rules: [{
       test: /\.(js|jsx)$/,
       loader: "babel-loader",
-      exclude: /node_modules/
+      exclude: /node_modules/,
+      options: {
+        presets: ["react"]
+      }
     }]
   },
   plugins: []

--- a/packages/startd-server/src/index.js
+++ b/packages/startd-server/src/index.js
@@ -26,13 +26,16 @@ if (!fs.existsSync(appPath)) {
 }
 
 if (!findUp.sync(".babelrc", { cwd: path.dirname(appPath) })) {
-  logger.error(
-    `Looks like you don't have a .babelrc file set up for your app. 👻`
+  logger.info(
+    `Looks like you don't have a .babelrc file set up for your app 👻`
   );
-  process.exit(1);
+  logger.info(
+    `  * by default startd transpiles your app using the react babel preset`
+  );
+  logger.info(`  * add a .babelrc file for other transpile options`);
 }
 
-logger.info(chalk.gray("Starting webpack compilation... 🕸"));
+logger.info("Starting webpack compilation... 🕸");
 
 const appConfig = config.map(singleConfig => ({
   ...singleConfig,
@@ -63,11 +66,9 @@ webpack(appConfig, (err, multiStats) => {
     // watch mode and hot module replacement for the client code
     if (process.env.NODE_ENV !== "production") {
       logger.info(
-        chalk.gray(
-          'startd running in dev mode 🛠  make sure to add "--prod" flag when running in production'
-        )
+        'startd running in dev mode 🛠  make sure to add "--prod" flag when running in production'
       );
-      logger.info(chalk.gray("🛠  compiling webpack for dev server... 🕸"));
+      logger.info("🛠  compiling webpack for dev server... 🕸");
       const Koa = require("koa");
       const webpackDevMiddleware = require("koa-webpack");
 

--- a/packages/startd-server/src/logger.js
+++ b/packages/startd-server/src/logger.js
@@ -30,7 +30,7 @@ const debugLogger = winston.createLogger({
 
 export default {
   info: function(message: string) {
-    logger.log("info", message);
+    logger.log("info", chalk.gray(message));
   },
   error: function(message: string) {
     logger.log("error", message);

--- a/packages/startd-server/src/webpack.config.js
+++ b/packages/startd-server/src/webpack.config.js
@@ -10,7 +10,10 @@ const baseConfig = {
       {
         test: /\.(js|jsx)$/,
         loader: "babel-loader",
-        exclude: /node_modules/
+        exclude: /node_modules/,
+        options: {
+          presets: ["react"]
+        }
       }
     ]
   },


### PR DESCRIPTION
https://github.com/mgrip/startd/issues/3

Default to using react babel preset so that users can use startd without
a .babelrc file present